### PR TITLE
Simplify requirements and add notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,163 @@
+# From: https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/

--- a/README.md
+++ b/README.md
@@ -25,16 +25,21 @@
 ### Dependencies
 
 Install PyTorch and other dependencies:
+``````
+conda create --name brepgen_env python=3.9 -y
+conda activate brepgen_env
 
-    pip install -r requirements.txt
+pip install -r requirements.txt
+pip install chamferdist
+```
 
-Install Diffusers: 
+If `chamferdist` fails to install here are a few options to try:
 
-    pip install diffusers["torch"] transformers
+- If there is a CUDA version mismatch error, then try setting the `CUDA_HOME` environment variable to point to CUDA installation folder. The CUDA version of this folder must match with PyTorch's version i.e. 11.8.
+
+- Try [building from source](https://github.com/krrish94/chamferdist?tab=readme-ov-file#building-from-source).
 
 Install OCCWL following the instruction [here](https://github.com/AutodeskAILab/occwl).
-
-Note:  try [building from source](https://github.com/krrish94/chamferdist?tab=readme-ov-file#building-from-source) if ```pip install chamferdist``` does not work.
 
 
 ## Data

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ If `chamferdist` fails to install here are a few options to try:
 - Try [building from source](https://github.com/krrish94/chamferdist?tab=readme-ov-file#building-from-source).
 
 Install OCCWL following the instruction [here](https://github.com/AutodeskAILab/occwl).
+If conda is stuck in "Solving environment..." there are two options to try:
 
+- Try using `mamba` as suggested in occwl's README.
+
+- Install pythonOCC: https://github.com/tpaviot/pythonocc-core?tab=readme-ov-file#install-with-conda and occwl manually: `pip install git+https://github.com/AutodeskAILab/occwl`.
 
 ## Data
 Download [ABC](https://archive.nyu.edu/handle/2451/43778) STEP files (100 folders), or the [Furniture Data](https://drive.google.com/file/d/16nXl7OXOZtPxRhkGobOezDTXiBisEVs2/view?usp=sharing). 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 torch
 torchvision
 torchaudio
-
-chamferdist
+diffusers[torch]==0.27
+transformers
 wandb
+matplotlib


### PR DESCRIPTION
I moved `diffusers` and `transformers`, and added `matplotlib` into the `requirements.txt` file, and made installing `chamferdist` as a separate step. This is because when pip attempts to build from source, `chamferdist` tries to import torch in its `setup.py` file before pip has a chance to install it as noted here: https://github.com/krrish94/chamferdist/issues/12#issuecomment-785469050

I added some notes on `chamferdist` and `occwl` which might be helpful to people trying to set up the environment.